### PR TITLE
feat(command): implement duplicate statement command

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,14 @@
             {
                 "command": "moveStatementDown",
                 "title": "Move Statement Down"
+            },
+            {
+                "command": "copyStatementUp",
+                "title": "Copy Statement Up"
+            },
+            {
+                "command": "copyStatementDown",
+                "title": "Copy Statement Down"
             }
         ],
         "configurationDefaults": {

--- a/src/copyStatement.ts
+++ b/src/copyStatement.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode'
+import { getCommaHandledContent, getWhitespaceLines } from './shared'
+
+export default async (
+    editor: vscode.TextEditor,
+    direction: -1 | 1,
+    match:
+        | Record<'prev' | 'current' | 'next', vscode.DocumentSymbol | undefined> & {
+              current: vscode.DocumentSymbol
+              isCurrentLast: boolean
+              isNextLast: boolean
+          },
+    relatedSettings: { builtinCommaHandling?: boolean },
+) => {
+    const curRange = match.current.range
+    const { builtinCommaHandling = false } = relatedSettings
+    const { document } = editor
+
+    // always moved together
+    const surroundedEmptyLines = getWhitespaceLines(direction === 1 ? curRange.end.line : curRange.start.line, direction, document)
+    const surroundedEmptyLinesContent = surroundedEmptyLines.length > 0 ? `\n${surroundedEmptyLines.join('\n')}` : ''
+
+    const currentLinesRange = new vscode.Range(curRange.start.with(undefined, 0), curRange.end.with(undefined, Number.POSITIVE_INFINITY))
+
+    const currentLinesContent = document.getText(currentLinesRange)
+
+    const { contentClean, endsComma } = getCommaHandledContent(currentLinesContent)
+
+    const newContentHandled = (): string => {
+        if (!endsComma || !builtinCommaHandling) return currentLinesContent
+        // todo check also range end, end+1
+        if (direction === 1 && match.isNextLast && endsComma)
+            return currentLinesContent.slice(0, contentClean.length - 1) + currentLinesContent.slice(contentClean.length)
+        if (direction === -1 && match.isCurrentLast && !endsComma)
+            return `${currentLinesContent.slice(0, contentClean.length)},${currentLinesContent.slice(contentClean.length)}`
+
+        return currentLinesContent
+    }
+
+    await editor.edit(edit => {
+        if (direction === -1) edit.insert(curRange.start.with(undefined, 0), `${newContentHandled()}${surroundedEmptyLinesContent}\n`)
+        else edit.insert(curRange.end.with(undefined, Number.POSITIVE_INFINITY), `\n${surroundedEmptyLinesContent}${newContentHandled()}`)
+    })
+    return (curRange.end.line - curRange.start.line) * direction
+}

--- a/src/copyStatement.ts
+++ b/src/copyStatement.ts
@@ -28,7 +28,6 @@ export default async (
 
     const newContentHandled = (): string => {
         if (!endsComma || !builtinCommaHandling) return currentLinesContent
-        // todo check also range end, end+1
         if (direction === 1 && match.isNextLast && endsComma)
             return currentLinesContent.slice(0, contentClean.length - 1) + currentLinesContent.slice(contentClean.length)
         if (direction === -1 && match.isCurrentLast && !endsComma)
@@ -41,7 +40,10 @@ export default async (
         if (direction === -1) edit.insert(curRange.start.with(undefined, 0), `${newContentHandled()}${surroundedEmptyLinesContent}\n`)
         else edit.insert(curRange.end.with(undefined, Number.POSITIVE_INFINITY), `\n${surroundedEmptyLinesContent}${newContentHandled()}`)
     })
-    const lineDiff = (curRange.end.line - curRange.start.line) * direction
-    if (direction === -1 && Math.abs(lineDiff) > curRange.start.line) return 0
-    return lineDiff
+    if (direction === -1) return 0
+
+    const lineDiff = curRange.end.line - curRange.start.line
+    if (lineDiff === 0) return 1
+
+    return lineDiff * 2 + 1
 }

--- a/src/copyStatement.ts
+++ b/src/copyStatement.ts
@@ -41,5 +41,7 @@ export default async (
         if (direction === -1) edit.insert(curRange.start.with(undefined, 0), `${newContentHandled()}${surroundedEmptyLinesContent}\n`)
         else edit.insert(curRange.end.with(undefined, Number.POSITIVE_INFINITY), `\n${surroundedEmptyLinesContent}${newContentHandled()}`)
     })
-    return (curRange.end.line - curRange.start.line) * direction
+    const lineDiff = (curRange.end.line - curRange.start.line) * direction
+    if (direction === -1 && Math.abs(lineDiff) > curRange.start.line) return 0
+    return lineDiff
 }

--- a/src/copyStatement.ts
+++ b/src/copyStatement.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import { getCommaHandledContent, getHandledContent, getWhitespaceLines } from './shared'
+import { getCommaHandledContent, getHandledContent } from './shared'
 
 export default async (
     editor: vscode.TextEditor,
@@ -16,9 +16,6 @@ export default async (
     const { builtinCommaHandling = false } = relatedSettings
     const { document } = editor
 
-    const surroundedEmptyLines = getWhitespaceLines(direction === 1 ? curRange.end.line : curRange.start.line, direction, document)
-    const surroundedEmptyLinesContent = surroundedEmptyLines.length > 0 ? `\n${surroundedEmptyLines.join('\n')}` : ''
-
     const currentLinesRange = new vscode.Range(curRange.start.with(undefined, 0), curRange.end.with(undefined, Number.POSITIVE_INFINITY))
 
     const currentLinesContent = document.getText(currentLinesRange)
@@ -27,8 +24,8 @@ export default async (
 
     const contentToInsert = !endsComma || !builtinCommaHandling ? currentLinesContent : getHandledContent(currentLinesContent, direction, match)
     await editor.edit(edit => {
-        if (direction === -1) edit.insert(curRange.start.with(undefined, 0), `${contentToInsert}${surroundedEmptyLinesContent}\n`)
-        else edit.insert(curRange.end.with(undefined, Number.POSITIVE_INFINITY), `\n${surroundedEmptyLinesContent}${contentToInsert}`)
+        if (direction === -1) edit.insert(curRange.start.with(undefined, 0), `${contentToInsert}\n`)
+        else edit.insert(curRange.end.with(undefined, Number.POSITIVE_INFINITY), `\n${contentToInsert}`)
     })
     if (direction === -1) return 0
 

--- a/src/copyStatement.ts
+++ b/src/copyStatement.ts
@@ -23,10 +23,13 @@ export default async (
     const { endsComma } = getCommaHandledContent(currentLinesContent)
 
     const contentToInsert = !endsComma || !builtinCommaHandling ? currentLinesContent : getHandledContent(currentLinesContent, direction, match)
-    await editor.edit(edit => {
-        if (direction === -1) edit.insert(curRange.start.with(undefined, 0), `${contentToInsert}\n`)
-        else edit.insert(curRange.end.with(undefined, Number.POSITIVE_INFINITY), `\n${contentToInsert}`)
-    })
+    await editor.edit(
+        edit => {
+            if (direction === -1) edit.insert(curRange.start.with(undefined, 0), `${contentToInsert}\n`)
+            else edit.insert(curRange.end.with(undefined, Number.POSITIVE_INFINITY), `\n${contentToInsert}`)
+        },
+        { undoStopAfter: false, undoStopBefore: false }, // undo all edits with one `undo` command in multicursor case
+    )
     if (direction === -1) return 0
 
     const lineDiff = curRange.end.line - curRange.start.line

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ export const activate = () => {
         if (supportedKinds.length === 0) return
         const outline: vscode.DocumentSymbol[] = await vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', document.uri)
         const newSelections: vscode.Selection[] = []
-        for (const selection of selections) {
+        for await (const selection of selections) {
             const { start: startPos, end: endPos } = selection
             const findMe = (
                 items: vscode.DocumentSymbol[],
@@ -66,7 +66,6 @@ export const activate = () => {
             const match = findMe(outline)
             if (!match) continue
 
-            // eslint-disable-next-line no-await-in-loop
             const linesDiff = await handler(editor, direction, match, affectingConfiguration)
 
             if (commandAction === 'move') newSelections.push(new vscode.Selection(startPos.translate(linesDiff), endPos.translate(linesDiff)))

--- a/src/moveStatement.ts
+++ b/src/moveStatement.ts
@@ -1,0 +1,122 @@
+import * as vscode from 'vscode'
+import { offsetPosition } from '@zardoy/vscode-utils/build/position'
+
+export default async (
+    editor: vscode.TextEditor,
+    direction: -1 | 1,
+    match:
+        | Record<'prev' | 'current' | 'next', vscode.DocumentSymbol | undefined> & {
+              current: vscode.DocumentSymbol
+              isCurrentLast: boolean
+              isNextLast: boolean
+          },
+    relatedSettings: { rejectDifferentKinds: boolean; builtinCommaHandling: boolean },
+) => {
+    // const { current } = match
+    const curRange = match.current.range
+    const { rejectDifferentKinds, builtinCommaHandling } = relatedSettings
+    const { document } = editor
+
+    const swap = direction === 1 ? match.next : match.prev
+
+    if (!swap || (rejectDifferentKinds && swap.kind !== match.current.kind)) return
+    const swapRange = swap.range
+
+    // always moved together
+    const surroundedEmptyLines = getWhitespaceLines(
+        direction === 1 ? curRange.end.line : curRange.start.line /* todo swapRange.end.line */,
+        direction,
+        document,
+    )
+    const surroundedEmptyLinesCount = surroundedEmptyLines.length
+    const surroundedEmptyLinesContent = surroundedEmptyLines.length > 0 ? `\n${surroundedEmptyLines.join('\n')}` : ''
+
+    const currentLinesRange = new vscode.Range(curRange.start.with(undefined, 0), curRange.end.with(undefined, Number.POSITIVE_INFINITY))
+
+    const currentLinesContent = document.getText(currentLinesRange)
+    // if (moveDirection === 1) currentLinesContent = `${surroundedEmptyLinesContent}${currentLinesContent}`
+    // else currentLinesContent += surroundedEmptyLinesContent
+    const currentLinesRemoveRange =
+        direction === -1
+            ? currentLinesRange.with({
+                  start: currentLinesRange.start.translate(-surroundedEmptyLinesCount),
+                  end: expandPosWithEol(1, currentLinesRange.end, document),
+              })
+            : currentLinesRange.with(expandPosWithEol(-1, currentLinesRange.start, document), currentLinesRange.end.translate(surroundedEmptyLinesCount))
+
+    const linesBetween = direction === 1 ? swapRange.start.line - curRange.end.line : curRange.start.line - swapRange.end.line
+
+    const { contentClean, endsComma } = getCommaHandledContent(currentLinesContent)
+
+    const swapLinesRange = swapRange.with({ end: swapRange.end.with(undefined, Number.POSITIVE_INFINITY) })
+    const swapContent = document.getText(swapLinesRange)
+    const { contentClean: swapContentClean, endsComma: swapEndsComma } = getCommaHandledContent(swapContent)
+    const handlePrevContentComma = (edit: vscode.TextEditorEdit) => {
+        if (!builtinCommaHandling) return
+        // todo check also range end
+        const endPos = offsetPosition(document, swapRange.start, swapContentClean.length)
+        if (direction === 1 && match.isNextLast && !swapEndsComma) edit.insert(endPos, ',')
+        if (direction === -1 && match.isCurrentLast && swapEndsComma) edit.delete(new vscode.Range(endPos.translate(0, -1), endPos))
+        return swapEndsComma
+    }
+
+    const newContentHandled = (): string => {
+        if ((!endsComma && !swapEndsComma) || !builtinCommaHandling) return currentLinesContent
+        // todo check also range end, end+1
+        if (direction === 1 && match.isNextLast && endsComma)
+            return currentLinesContent.slice(0, contentClean.length - 1) + currentLinesContent.slice(contentClean.length)
+        if (direction === -1 && match.isCurrentLast && !endsComma)
+            return `${currentLinesContent.slice(0, contentClean.length)},${currentLinesContent.slice(contentClean.length)}`
+
+        return currentLinesContent
+    }
+
+    await editor.edit(edit => {
+        if (endsComma || swapEndsComma) handlePrevContentComma(edit)
+
+        edit.delete(currentLinesRemoveRange)
+
+        if (direction === -1) edit.insert(swapRange.start.with(undefined, 0), `${newContentHandled()}\n${surroundedEmptyLinesContent}`)
+        else edit.insert(swapRange.end.with(undefined, Number.POSITIVE_INFINITY), `\n${surroundedEmptyLinesContent}${newContentHandled()}`)
+    })
+    return (swapRange.end.line - swapRange.start.line + linesBetween) * direction
+}
+
+const getCommaHandledContent = (content: string) => {
+    const contentClean = content.replace(/[\n\s]+$/, '')
+    return {
+        contentClean,
+        endsComma: contentClean.endsWith(','),
+    }
+}
+
+const expandPosWithEol = (direction: -1 | 1, pos: vscode.Position, document: vscode.TextDocument) => {
+    if (direction === -1) {
+        const prevLine = getLineSafe(document, pos.line - 1)
+        return prevLine?.range.end ?? pos
+    }
+
+    return document.lineAt(pos).rangeIncludingLineBreak.end
+}
+
+const getWhitespaceLines = (lineNum: number, direction: 1 | -1, document: vscode.TextDocument) => {
+    const lines: string[] = []
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        lineNum += direction
+        const line = getLineSafe(document, lineNum)
+        if (!line || !line.isEmptyOrWhitespace) break
+        // keep whitespaces as is, not our problem
+        lines.push(line.text)
+    }
+
+    return lines
+}
+
+const getLineSafe = (document: vscode.TextDocument, line: number) => {
+    try {
+        return document.lineAt(line)
+    } catch {
+        return null
+    }
+}

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,5 +1,25 @@
 import * as vscode from 'vscode'
 
+export const getHandledContent = (
+    currentLinesContent: string,
+    direction: -1 | 1,
+    match:
+        | Record<'prev' | 'current' | 'next', vscode.DocumentSymbol | undefined> & {
+              current: vscode.DocumentSymbol
+              isCurrentLast: boolean
+              isNextLast: boolean
+          },
+): string => {
+    const { contentClean, endsComma } = getCommaHandledContent(currentLinesContent)
+    // todo check also range end, end+1
+    if (direction === 1 && match.isNextLast && endsComma)
+        return currentLinesContent.slice(0, contentClean.length - 1) + currentLinesContent.slice(contentClean.length)
+    if (direction === -1 && match.isCurrentLast && !endsComma)
+        return `${currentLinesContent.slice(0, contentClean.length)},${currentLinesContent.slice(contentClean.length)}`
+
+    return currentLinesContent
+}
+
 export const getCommaHandledContent = (content: string) => {
     const contentClean = content.replace(/[\n\s]+$/, '')
     return {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode'
+
+export const getCommaHandledContent = (content: string) => {
+    const contentClean = content.replace(/[\n\s]+$/, '')
+    return {
+        contentClean,
+        endsComma: contentClean.endsWith(','),
+    }
+}
+
+export const expandPosWithEol = (direction: -1 | 1, pos: vscode.Position, document: vscode.TextDocument) => {
+    if (direction === -1) {
+        const prevLine = getLineSafe(document, pos.line - 1)
+        return prevLine?.range.end ?? pos
+    }
+
+    return document.lineAt(pos).rangeIncludingLineBreak.end
+}
+
+export const getWhitespaceLines = (lineNum: number, direction: 1 | -1, document: vscode.TextDocument) => {
+    const lines: string[] = []
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        lineNum += direction
+        const line = getLineSafe(document, lineNum)
+        if (!line || !line.isEmptyOrWhitespace) break
+        // keep whitespaces as is, not our problem
+        lines.push(line.text)
+    }
+
+    return lines
+}
+
+const getLineSafe = (document: vscode.TextDocument, line: number) => {
+    try {
+        return document.lineAt(line)
+    } catch {
+        return null
+    }
+}


### PR DESCRIPTION
Resolves #2 
I think I've managed to preserve `moveStatement` functionality with all these refactorings. 
Copying up/down works well in single-selection cases, but I have trouble making it work with multi-cursor. So, I'll set it on draft until I manage how to fix it.